### PR TITLE
Migrate extension background to Manifest V3

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,8 +3,8 @@
 	"description": "Adds a button on various movie & TV show sites to open the item in Plex, or send to your designated NZB manager for download.",
 	"homepage_url": "https://webtoplex.github.io/",
 
-	"manifest_version": 2,
-	"version": "4.1.2.4",
+"manifest_version": 3,
+"version": "4.1.2.4",
 
 	"icons": {
 		"16":  "img/16.png",
@@ -15,7 +15,9 @@
 		"256": "img/256.png"
 	},
 
-	"content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+"content_security_policy": {
+"extension_pages": "script-src 'self' 'unsafe-eval'; object-src 'self'"
+},
 
 	"content_scripts": [
 		{
@@ -189,10 +191,9 @@
 		}
 	],
 
-	"background": {
-		"scripts": ["background.js", "plugn.js"],
-		"persistent": true
-	},
+        "background": {
+                "service_worker": "background.js"
+        },
 
 	"options_page": "options/index.html",
 	"options_ui": {
@@ -200,23 +201,29 @@
 		"open_in_tab": true
 	},
 
-	"browser_action": {
-		"default_icon": {
-			"16": "img/16.png",
-			"32": "img/32.png",
-			"48": "img/48.png",
-			"96": "img/96.png"
-		},
-		"default_title": "Web to Plex",
-		"default_popup": "popup/index.html"
-	},
+        "action": {
+                "default_icon": {
+                        "16": "img/16.png",
+                        "32": "img/32.png",
+                        "48": "img/48.png",
+                        "96": "img/96.png"
+                },
+                "default_title": "Web to Plex",
+                "default_popup": "popup/index.html"
+        },
 
-	"permissions": [
-		"tabs",
-		"storage",
-		"downloads",
-		"contextMenus",
-		"<all_urls>"
-	],
-	"web_accessible_resources": ["font/*", "img/*", "options/*", "sites/*.css"]
+        "permissions": [
+                "tabs",
+                "storage",
+                "downloads",
+                "contextMenus",
+                "scripting"
+        ],
+        "host_permissions": ["<all_urls>"],
+        "web_accessible_resources": [
+                {
+                        "resources": ["font/*", "img/*", "options/*", "sites/*.css"],
+                        "matches": ["<all_urls>"]
+                }
+        ]
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -3920,8 +3920,15 @@ Object.filter = Object.filter || function filter(object, prejudice) {
 						} catch (__error) {
 							try {
 								/* Not a Chrome (extension) state */
-								chrome.tabs.getCurrent(tab => chrome.tabs.executeScript(tab.id, { code: `document.furnish.__cache__ = () => {${ value }}` }, __cache__ => element[name] = __cache__[0] || parent.furnish.__cache__ || value));
-							} catch (_error) {
+                                                                chrome.tabs.getCurrent(tab => chrome.scripting.executeScript({
+                                                                        target: { tabId: tab.id },
+                                                                        func: cached => {
+                                                                                document.furnish.__cache__ = () => { return eval(cached); };
+                                                                                return document.furnish.__cache__();
+                                                                        },
+                                                                        args: [value]
+                                                                }).then(__cache__ => element[name] = (__cache__[0] && __cache__[0].result) || parent.furnish.__cache__ || value));
+                                                        } catch (_error) {
 								throw __error, _error;
 							}
 						}


### PR DESCRIPTION
## Summary
- update the manifest to v3 with a service worker background, the new action key, and MV3 web accessible resource/permission formats
- refactor the background and plugin scripts to use storage-based caching, chrome.action, and chrome.scripting helpers compatible with MV3 service workers
- adjust utils event handler fallback to rely on chrome.scripting for dynamic script injection

## Testing
- npm run lint (fails: existing lint issues in repo)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69290215d1dc8333a43506680ea9bb1f)